### PR TITLE
add oLog to obray

### DIFF
--- a/core/ODBO.php
+++ b/core/ODBO.php
@@ -923,21 +923,30 @@
 
         ********************************************************************/
 
-        public function run( $sql ){
+        public function run( $sql ) {
 
-        	if( is_array($sql) ){ $sql = $sql["sql"]; }
-	        $statement = $this->dbh->prepare($sql);
-            $result = $statement->execute();
+			if (is_array($sql)) {
+				$sql = $sql["sql"];
+			}
+			$statement = $this->dbh->prepare($sql);
+			$result = $statement->execute();
 			$this->data = [];
-			if(preg_match("/^select/i",$sql)){
+			if (preg_match("/^select/i", $sql)) {
 				$statement->setFetchMode(PDO::FETCH_OBJ);
-				try { while ($row = $statement->fetch()) { $this->data[] = $row; } } catch(Exception $e) {	$this->throwError($e); }
+				try {
+					while ($row = $statement->fetch()) {
+						$this->data[] = $row;
+					}
+				} catch (Exception $e) {
+					$this->throwError($e);
+					$this->logError(oProjectEnum::ODBO,$e);
+				}
 			} else {
 				$this->data = $result;
 			}
-			
+
 			return $this;
-        }
+		}
 
         /********************************************************************
 

--- a/core/OObject.php
+++ b/core/OObject.php
@@ -416,6 +416,7 @@
 
 				        } catch (Exception $e){
 				        	$this->throwError($e->getMessage());
+							$this->logError(oProjectEnum::OOBJECT,$e);
 				       	}
 
 					}
@@ -437,25 +438,35 @@
 
 		***********************************************************************/
 
-		private function executeMethod($path,$path_array,$direct,&$params){
+		private function executeMethod($path,$path_array,$direct,&$params) {
 
-			$path = str_replace('-','',$path_array[0]);
+			$path = str_replace('-', '', $path_array[0]);
 
-			if( method_exists($this,$path) ){
-			   try{
-					$params = array_merge($this->checkPermissions($path,$direct),$params);
-					if( !$this->isError() ){ $this->$path($params); }
-				} catch (Exception $e){ $this->throwError($e->getMessage()); }
+			if (method_exists($this, $path)) {
+				try {
+					$params = array_merge($this->checkPermissions($path, $direct), $params);
+					if (!$this->isError()) {
+						$this->$path($params);
+					}
+				} catch (Exception $e) {
+					$this->throwError($e->getMessage());
+					$this->logError(oProjectEnum::ODBO,$e);
+				}
 				return $this;
-		    } else if( method_exists($this,"index") ) {
-				try{
-					$params = array_merge($this->checkPermissions("index",$direct),$params);
-					if( !$this->isError() ){ $this->index($params); }
-				} catch (Exception $e){ $this->throwError($e->getMessage()); }
-		    	return $this;
-		    } else {
-		    	return $this->findMissingRoute($path,$params);
-		    }
+			} else if (method_exists($this, "index")) {
+				try {
+					$params = array_merge($this->checkPermissions("index", $direct), $params);
+					if (!$this->isError()) {
+						$this->index($params);
+					}
+				} catch (Exception $e) {
+					$this->throwError($e->getMessage());
+					$this->logError(oProjectEnum::ODBO,$e);
+				}
+				return $this;
+			} else {
+				return $this->findMissingRoute($path, $params);
+			}
 		}
 
 		/***********************************************************************
@@ -682,6 +693,30 @@
 
 		public function startSocketServer( $params=array() ){
 
+		}
+
+		/***********************************************************************
+
+		LOGGING FUNCTIONS
+
+		 ***********************************************************************/
+
+		public function logError($oProjectEnum, Exception $exception, $customMessage="") {
+			$logger = new oLog();
+			$logger->logError($oProjectEnum, $exception, $customMessage);
+			return;
+		}
+
+		public function logInfo($oProjectEnum, $message) {
+			$logger = new oLog();
+			$logger->logInfo($oProjectEnum, $message);
+			return;
+		}
+
+		public function logDebug($oProjectEnum, $message) {
+			$logger = new oLog();
+			$logger->logInfo($oProjectEnum, $message);
+			return;
 		}
 
 	}

--- a/core/OObject.php
+++ b/core/OObject.php
@@ -617,6 +617,43 @@
 	    }
 		public function isError(){ return $this->is_error; }
 
+		public function getStackTrace($exception) {
+			$stackTrace = "";
+			$count = 0;
+			foreach ($exception->getTrace() as $frame) {
+				$args = "";
+				if (isset($frame['args'])) {
+					$args = array();
+					foreach ($frame['args'] as $arg) {
+						if (is_string($arg)) {
+							$args[] = "'" . $arg . "'";
+						} elseif (is_array($arg)) {
+							$args[] = "Array";
+						} elseif (is_null($arg)) {
+							$args[] = 'NULL';
+						} elseif (is_bool($arg)) {
+							$args[] = ($arg) ? "true" : "false";
+						} elseif (is_object($arg)) {
+							$args[] = get_class($arg);
+						} elseif (is_resource($arg)) {
+							$args[] = get_resource_type($arg);
+						} else {
+							$args[] = $arg;
+						}
+					}
+					$args = join(", ", $args);
+				}
+				$stackTrace .= sprintf( "#%s %s(%s): %s(%s)\n",
+					$count,
+					$frame['file'],
+					$frame['line'],
+					$frame['function'],
+					$args );
+				$count++;
+			}
+			return $stackTrace;
+		}
+
 		/***********************************************************************
 
 			GETTER AND SETTER FUNCTIONS

--- a/core/ORouter.php
+++ b/core/ORouter.php
@@ -29,7 +29,8 @@
 	require_once 'OObject.php';                                                         // the base object for all obray objects (basically everything will extend this or a class that has already extended it)
 	require_once 'ODBO.php';                                                            // object that extends OObject but includes database functionality and table definition support
 	require_once 'oCLI.php';															// object that provides a command line interface to obray applications
-	require_once 'OUsers.php';															// provides user authentication and permissions
+	require_once 'OUsers.php';                                                          // provides user authentication and permissions
+    require_once 'oLog.php';                                                            // object that provides logging functionality
 	if (!class_exists( 'OObject' )) { die(); }
 
 

--- a/core/oLog.php
+++ b/core/oLog.php
@@ -1,0 +1,60 @@
+<?php
+
+if (!class_exists( 'OObject' )) { die(); }
+
+class oProjectEnum {
+    const ANALYTICS = 'Analytics';
+    const INVENTORY = 'Inventory';
+    Const ODBO = 'ODBO';
+    Const OOBJECT = 'OObject';
+    const REPORTS = 'Reports';
+}
+
+class oLogTypeEnum {
+    const DEBUG = 'Debug';
+    const ERROR = 'Error';
+    const INFO = 'Info';
+}
+
+class oLog extends OObject {
+    public function __construct(){
+
+        $this->permissions = array(
+            'object' => 1,
+            'logError' => 1,
+            'logInfo' => 1,
+            'logDebug' => 1
+        );
+    }
+
+    public function logError($oProjectEnum, Exception $exception, $customMessage=""){
+        $message = $exception->getMessage().PHP_EOL.$this->getStackTrace($exception);
+        $filepath = $this->getFilePath($oProjectEnum, oLogTypeEnum::ERROR);
+        $message = date('Y-m-d h:i:s', time()).' '.$message.PHP_EOL;
+        $this->writeLog($filepath, $message);
+    }
+
+    public function logInfo($oProjectEnum, $message) {
+        $message = date('Y-m-d h:i:s', time()).' '.$message.PHP_EOL;
+        $filepath = $this->getFilePath($oProjectEnum, oLogTypeEnum::INFO);
+        $this->writeLog($filepath, $message);
+    }
+
+    public function logDebug($oProjectEnum, $message) {
+        $message = date('Y-m-d h:i:s', time()).' '.$message.PHP_EOL;
+        $filepath = $this->getFilePath($oProjectEnum, oLogTypeEnum::DEBUG);
+        $this->writeLog($filepath, $message);
+    }
+
+    private function getFilePath($oProjectEnum, $oLogTypeEnum) {
+        $filepath = __LOGS__.__APP__.'/'.$oProjectEnum.'/'.$oLogTypeEnum.'/'.Date('Y-m-d').'_'.$oProjectEnum.'.log';
+        return $filepath;
+    }
+
+    private function writeLog($filepath, $message) {
+        if(!file_exists(dirname($filepath))) {
+            mkdir(dirname($filepath),0755, true);
+        }
+        file_put_contents($filepath, $message.PHP_EOL, FILE_APPEND | LOCK_EX);
+    }
+}


### PR DESCRIPTION
This merge would incorporate oLog into obray and would begin to log all exceptions thrown on object creation in OObject, or sql statements run in ODBO. It also makes the following functions available across the entire application:

$this->logError
$this->logInfo
$this->logDebug

This requires an update to the settings.php file to define a __LOGS__ variable that points to the directory you would like to log to.  The settings.php on hq has been updated to include this variable, and the /log/ directory has been created with proper permissions.