### PR TITLE
updated headers to be array instead of string for PHP7 compatibility

### DIFF
--- a/core/OObject.php
+++ b/core/OObject.php
@@ -60,7 +60,7 @@
 	if (!function_exists('getallheaders')){
         function getallheaders()
         {
-               $headers = '';
+               $headers = [];
            foreach ($_SERVER as $name => $value)
            {
                if (substr($name, 0, 5) == 'HTTP_')


### PR DESCRIPTION
This is the fix that was needed on all my dev php7 branches for php-fpm to not error out.