### PR TITLE
Forward output object when routing

### DIFF
--- a/core/OObject.php
+++ b/core/OObject.php
@@ -500,6 +500,7 @@ class OObject
 						$obj->path_to_object = implode('/', $path_array);
 						array_pop($rPath);
 						$obj->rPath = $rPath;
+						$obj->setOutput($this->output);
 
 						//	CHECK PERMISSIONS
 						$params = array_merge($obj->checkPermissions('object', $direct), $params);


### PR DESCRIPTION
Forward the output object when routing through Obray. This will enable setting the output to a NullOutput object, and that will be persisted through any route calls. The benefit this provides is that tests will have cleaner output without having to explicitly set the output object on nested route calls.

It also allows capturing the output, so that it can be used in assertions, or formatted or transmitted to another location other than std out.