### PR TITLE
Optional JSON_NUMERIC_CHECK

### DIFF
--- a/core/ORouter.php
+++ b/core/ORouter.php
@@ -121,7 +121,7 @@ class ORouter extends OObject
 		}
 
 		// check if `JSON_NUMERIC_CHECK` should be used for this route
-		$jsonNumericCheck = $obj->jsonNumericCheck ?? true;
+		$jsonNumericCheck = (isset($obj->jsonNumericCheck) && is_bool($obj->jsonNumericCheck)) ? $obj->jsonNumericCheck : true;
 
 		/*****************************************************************************************
 		 *

--- a/core/ORouter.php
+++ b/core/ORouter.php
@@ -143,7 +143,7 @@ class ORouter extends OObject
                     $encodingFlags |= JSON_NUMERIC_CHECK;
                 }
 
-				$json = json_encode($obj, JSON_PRETTY_PRINT | JSON_NUMERIC_CHECK);
+				$json = json_encode($obj, $encodingFlags);
 				if ($json === FALSE) {
 					$json = json_encode($obj, JSON_PRETTY_PRINT);
 				}

--- a/core/ORouter.php
+++ b/core/ORouter.php
@@ -120,6 +120,8 @@ class ORouter extends OObject
 			$content_type = $tmp_type;
 		}
 
+		// check if `JSON_NUMERIC_CHECK` should be used for this route
+		$jsonNumericCheck = $obj->jsonNumericCheck ?? true;
 
 		/*****************************************************************************************
 		 *
@@ -135,6 +137,12 @@ class ORouter extends OObject
 			case 'application/json':                                                            // Handle JSON (default)
 
 				$obj->runtime = (microtime(TRUE) - $start_time) * 1000;
+
+				$encodingFlags = JSON_PRETTY_PRINT;
+                if($jsonNumericCheck){
+                    $encodingFlags |= JSON_NUMERIC_CHECK;
+                }
+
 				$json = json_encode($obj, JSON_PRETTY_PRINT | JSON_NUMERIC_CHECK);
 				if ($json === FALSE) {
 					$json = json_encode($obj, JSON_PRETTY_PRINT);


### PR DESCRIPTION
### Problem
Currently, there is no way to disable the `JSON_NUMERIC_CHECK` flag from the `json_encode` call in `oRouter`. String output that can be converted to numbers will have the leading zeros removed, which can cause issues for functionality that depends on the full character set being present.

### Solution
Allow the route to specify a public boolean `jsonNumericCheck` property that can toggle the `JSON_NUMERIC_CHECK` flag. This property will be unset when `OObject::cleanUp` is called by `oRouter`.

### Example
```php
public class cTest extends cRoot {
    // can be specified as a property
    public bool $jsonNumericCheck = false;

    // can be specified in a member function
    public function fooBar($params = []){
        $this->jsonNumericCheck = false;
    }
}
```