### PR TITLE
Record last exception

### DIFF
--- a/core/OObject.php
+++ b/core/OObject.php
@@ -32,6 +32,7 @@ class OObject
 
 	// public data members
 	public $object = ''; // stores the name of the class
+	protected Throwable $lastException;
 
 	public function console(...$args)
 	{
@@ -1003,6 +1004,7 @@ class OObject
 
 	public function logError($oProjectEnum, Exception $exception, $customMessage = "")
 	{
+		$this->lastException = $exception;
 		$logger = new oLog();
 		$logger->logError($oProjectEnum, $exception, $customMessage);
 	}
@@ -1023,5 +1025,10 @@ class OObject
 	{
 		$namespaceRoot = explode('/', realpath(__OBRAY_NAMESPACE_ROOT__));
 		return array_pop($namespaceRoot);
+	}
+
+	public function getLastException(): Throwable
+	{
+		return $this->lastException;
 	}
 }

--- a/core/oLog.php
+++ b/core/oLog.php
@@ -36,6 +36,7 @@ class oLog extends OObject
 
 	public function logError($oProjectEnum, Exception $exception, $customMessage = "")
 	{
+		$this->lastException = $exception;
 		if (isset(self::$exceptionHandler)) {
 			if (self::$exceptionHandler->shouldReport($exception)) {
 				self::$exceptionHandler->report($exception);

--- a/tests/Log/ExceptionHandlerTest.php
+++ b/tests/Log/ExceptionHandlerTest.php
@@ -47,5 +47,7 @@ class ExceptionHandlerTest extends TestCase
 		$this->assertCount(1, $reported);
 		$this->assertArrayhasKey(0, $reported);
 		$this->assertSame($exception, $reported[0]);
+
+		$this->assertSame($exception, $this->logger->getLastException());
 	}
 }


### PR DESCRIPTION
This will allow better error handling in scenarios like this
```
if(!empty($response->errors)){
    $this->console("%s","error\n","RedBold");
    throw new ObrayException($response->errors, 0, $response->getLastException());
}
```

It allows exception chaining.