### PR TITLE
Add authorization tests. Fix several bugs.

### DIFF
--- a/core/OObject.php
+++ b/core/OObject.php
@@ -1011,22 +1011,13 @@ class OObject
 	 */
 	protected function checkPermissionOrRole($allowedList, array $list): bool
 	{
-		if (!is_array($allowedList)) {
-			return false;
-		} else {
+		if (is_array($allowedList)) {
 			foreach ($allowedList as $allowedPermission) {
-				if (!is_string($allowedPermission)) {
-					return false;
+				if (in_array($allowedPermission, $list, true)) {
+					return true;
 				}
 			}
-
-			$matched = array_intersect($allowedList, $list);
-
-			if (count($matched) === 0) {
-				return false;
-			}
 		}
-
-		return true;
+		return false;
 	}
 }

--- a/core/OObject.php
+++ b/core/OObject.php
@@ -504,7 +504,7 @@ class OObject
 						$obj->setOutput($this->output);
 
 						//	CHECK PERMISSIONS
-						$params = array_merge($obj->checkPermissions('object', $direct), $params);
+						$obj->checkPermissions('object', $direct);
 
 						//	SETUP DATABASE CONNECTION
 						if (method_exists($obj, 'setDatabaseConnection')) {
@@ -571,7 +571,7 @@ class OObject
 
 		if (method_exists($this, $path)) {
 			try {
-				$params = array_merge($this->checkPermissions($path, $direct), $params);
+				$this->checkPermissions($path, $direct);
 				if (!$this->isError()) {
 					$this->$path($params);
 				}
@@ -583,7 +583,7 @@ class OObject
 			return $this;
 		} else if (method_exists($this, "index")) {
 			try {
-				$params = array_merge($this->checkPermissions("index", $direct), $params);
+				$this->checkPermissions("index", $direct);
 				if (!$this->isError()) {
 					$this->index($params);
 				}
@@ -601,111 +601,83 @@ class OObject
 	/***********************************************************************
 	 * CHECK PERMISSIONS
 	 ***********************************************************************/
-	private function checkPermissions($object_name, $direct)
+	private function checkPermissions($object_name, $direct): void
 	{
-		$params = array();
+		// Only restrict permissions if the call is come from and HTTP request through router $direct === FALSE
+		if ($direct) {
+			return;
+		}
 
-		// only restrict permissions if the call is come from and HTTP request through router $direct === FALSE
-		if (!$direct) {
+		$perms = $this->getPermissions();
 
-			// retrieve permissions
-			$perms = $this->getPermissions();
+		// If specific action has no permissions defined, attempt to authorize on the generic "method" permission
+		if (!isset($perms[$object_name]) && isset($perms['method'])) {
+			$object_name = 'method';
+		}
 
-			// set the "method" permission is set and the specific method has no permis then set the object_name to "method"
-			if (!isset($perms[$object_name]) && isset($perms['method'])) {
-				$object_name = 'method';
-			}
+		//This is to add greater flexibility for using custom session variable for storage of user data
+		$user_session_key = isset($this->user_session) ? $this->user_session : 'ouser';
 
-			//This is to add greater flexibility for using custom session variable for storage of user data
-			$user_session_key = isset($this->user_session) ? $this->user_session : 'ouser';
-
-			// restrict permissions on undefined keys
-			if (!isset($perms[$object_name])) {
-
+		switch (true) {
+			case !isset($perms[$object_name]):
 				$this->throwError('You cannot access this resource.', 403, 'Forbidden');
+				break;
+			case $perms[$object_name] === 'any':
+				break;
+			case $perms[$object_name] === 'user':
+				if (!isset($_SESSION[$user_session_key]) && isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
+					$this->route('/obray/OUsers/login/', array('ouser_email' => $_SERVER['PHP_AUTH_USER'], 'ouser_password' => $_SERVER['PHP_AUTH_PW']), TRUE);
+				}
 
-				// restrict access to users that are not logged in if that's required
-			} else if (($perms[$object_name] === 'user' && !isset($_SESSION[$user_session_key])) || (is_int($perms[$object_name]) && !isset($_SESSION[$user_session_key]))) {
-
-				if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
-					$login = $this->route('/obray/OUsers/login/', array('ouser_email' => $_SERVER['PHP_AUTH_USER'], 'ouser_password' => $_SERVER['PHP_AUTH_PW']), TRUE);
-					if (!isset($_SESSION[$user_session_key])) {
+				if (!isset($_SESSION[$user_session_key])) {
+					$this->throwError('You cannot access this resource.', 401, 'Unauthorized');
+				}
+				break;
+			case !isset($_SESSION[$user_session_key]): // Everything past this point requires an authenticated user
+				$this->throwError('You cannot access this resource.', 401, 'Unauthorized');
+				break;
+			case is_int($perms[$object_name]):
+				if (!isset($_SESSION[$user_session_key]->ouser_permission_level)) {
+					$this->throwError('You cannot access this resource.', 401, 'Unauthorized');
+				} elseif (defined("__OBRAY_GRADUATED_PERMISSIONS__")) {
+					if ($_SESSION[$user_session_key]->ouser_permission_level < $perms[$object_name]) {
 						$this->throwError('You cannot access this resource.', 401, 'Unauthorized');
 					}
 				} else {
-					$this->throwError('You cannot access this resource.', 401, 'Unauthorized');
+					if ($_SESSION[$user_session_key]->ouser_permission_level != $perms[$object_name]) {
+						$this->throwError('You cannot access this resource.', 401, 'Unauthorized');
+					}
+				}
+				break;
+			case is_array($perms[$object_name]):
+				$userPermissions = $_SESSION[$user_session_key]->permissions ?? [];
+				$userRoles = $_SESSION[$user_session_key]->roles ?? [];
+
+				if (array_key_exists('permissions', $perms[$object_name])) {
+					$allowedPermissions = $perms[$object_name]['permissions'];
+
+					if ($this->checkPermissionOrRole($allowedPermissions, $userPermissions)) {
+						break;
+					}
 				}
 
-				// restrict access to users without correct permissions (non-graduated)
-			} else if (is_int($perms[$object_name])
-				&& isset($_SESSION[$user_session_key])
-				&& (
-					isset($_SESSION[$user_session_key]->ouser_permission_level)
-					&& !defined("__OBRAY_GRADUATED_PERMISSIONS__")
-					&& $_SESSION[$user_session_key]->ouser_permission_level != $perms[$object_name]
-				)
-			) {
+				if (array_key_exists('roles', $perms[$object_name])) {
+					$allowedRoles = $perms[$object_name]['roles'];
 
-				$this->throwError('You cannot access this resource.', 403, 'Forbidden');
-
-				// restrict access to users without correct permissions (graduated)
-			} else if (is_int($perms[$object_name])
-				&& isset($_SESSION[$user_session_key])
-				&&
-				(
-					isset($_SESSION[$user_session_key]->ouser_permission_level)
-					&& defined("__OBRAY_GRADUATED_PERMISSIONS__")
-					&& $_SESSION[$user_session_key]->ouser_permission_level > $perms[$object_name]
-				)
-			) {
-
-				$this->throwError('You cannot access this resource.', 403, 'Forbidden');
-
-				// roles & permissions checks
-			} else if (
-				(
-					is_array($perms[$object_name]) &&
-					isset($perms[$object_name]['permissions']) &&
-					is_array($perms[$object_name]['permissions']) &&
-					count(array_intersect($perms[$object_name]['permissions'], $_SESSION[$user_session_key]->permissions)) == 0
-				) || (
-					is_array($perms[$object_name]) &&
-					isset($perms[$object_name]['roles']) &&
-					is_array($perms[$object_name]['roles']) &&
-					count(array_intersect($perms[$object_name]['roles'], $_SESSION[$user_session_key]->roles)) == 0
-				) || (
-					is_array($perms[$object_name]) &&
-					isset($perms[$object_name]['roles']) &&
-					is_array($perms[$object_name]['roles']) &&
-					in_array("SUPER", $_SESSION[$user_session_key]->roles)
-				) || (
-					is_array($perms[$object_name]) &&
-					isset($perms[$object_name]['permissions']) &&
-					!is_array($perms[$object_name]['permissions'])
-				) || (
-					is_array($perms[$object_name]) &&
-					isset($perms[$object_name]['roles']) &&
-					!is_array($perms[$object_name]['roles'])
-				) || (
-					is_array($perms[$object_name]) &&
-					!isset($perms[$object_name]['roles']) &&
-					!isset($perms[$object_name]['permissions'])
-				)
-			) {
-
-				$this->throwError('You cannot access this resource.', 403, 'Forbidden');
-
-				// add user_id to params if restriction is based on user
-			} else {
-
-				if (isset($perms[$object_name]) && $perms[$object_name] === 'user' && isset($_SESSION[$user_session_key])) {
-					$params['ouser_id'] = $_SESSION['ouser']->ouser_id;
+					if ($this->checkPermissionOrRole($allowedRoles, $userRoles)) {
+						break;
+					}
 				}
 
-			}
+				if (is_array($userRoles) && in_array("SUPER", $userRoles)) {
+					break;
+				}
+
+				$this->throwError('You cannot access this resource.', 403, 'Forbidden');
+				break;
+			default:
+				$this->throwError('You cannot access this resource.', 403, 'Forbidden');
 		}
-
-		return $params;
 	}
 
 	/***********************************************************************
@@ -1030,5 +1002,31 @@ class OObject
 	public function getLastException(): Throwable
 	{
 		return $this->lastException;
+	}
+
+	/**
+	 * @param $allowedList
+	 * @param array $list
+	 * @return void
+	 */
+	protected function checkPermissionOrRole($allowedList, array $list): bool
+	{
+		if (!is_array($allowedList)) {
+			return false;
+		} else {
+			foreach ($allowedList as $allowedPermission) {
+				if (!is_string($allowedPermission)) {
+					return false;
+				}
+			}
+
+			$matched = array_intersect($allowedList, $list);
+
+			if (count($matched) === 0) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/test_files/app/controllers/cPermissionController.php
+++ b/test_files/app/controllers/cPermissionController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\controllers;
+
+use OObject;
+
+class cPermissionController extends OObject
+{
+	public array $permissions = [
+		'object' => 'any',
+		'public' => 'any',
+		'user' => 'user',
+		'nonGraduated' => 1,
+		'graduated' => 1,
+		'permissionsAndRoles' => [
+			'permissions' => ['permission_access'],
+			'roles' => ['role_access'],
+		],
+	];
+
+	public function public()
+	{
+	}
+
+	public function noPermissionsListed()
+	{
+	}
+
+	public function user()
+	{
+	}
+
+	public function nonGraduated()
+	{
+	}
+
+	public function graduated()
+	{
+	}
+
+	public function permissionsAndRoles()
+	{
+	}
+}

--- a/test_files/app/controllers/cTestController.php
+++ b/test_files/app/controllers/cTestController.php
@@ -40,8 +40,8 @@ class cTestController extends OObject
 	public function getPermissions()
 	{
 		return [
-			'object' => 1,
-			'test' => 1,
+			'object' => 'any',
+			'test' => 'any',
 			'throwException' => 1,
 			'index' => 1,
 		];

--- a/test_files/models/OUsers.php
+++ b/test_files/models/OUsers.php
@@ -1,0 +1,17 @@
+<?php
+
+use tests\FakesAuthentication;
+
+class OUsers extends OObject
+{
+	use FakesAuthentication;
+
+	public static $shouldAuthenticate = true;
+
+	public function login()
+	{
+		if (static::$shouldAuthenticate) {
+			$this->authenticate();
+		}
+	}
+}

--- a/tests/FakesAuthentication.php
+++ b/tests/FakesAuthentication.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace tests;
+
+trait FakesAuthentication
+{
+	protected function authenticate()
+	{
+		global $_SESSION;
+		$_SESSION['ouser'] = new class {
+			public $ouser_id = 1;
+			public $ouser_permission_level = 1;
+		};
+	}
+}

--- a/tests/Object/PermissionsTest.php
+++ b/tests/Object/PermissionsTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace tests\Object;
+
+use App\controllers\cPermissionController;
+use OUsers;
+use tests\TestCase;
+
+/**
+ * @covers OObject::checkPermissions
+ * @covers OObject::checkPermissionOrRole
+ */
+class PermissionsTest extends TestCase
+{
+	protected array $defaultForbiddenErrors = [
+		'Forbidden' => [
+			'You cannot access this resource.',
+		],
+	];
+
+	public function testFetchObjectNoAuth()
+	{
+		$response = $this->route('PermissionController');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testFetchObjectAuth()
+	{
+		$this->authenticate();
+		$response = $this->route('PermissionController');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testPublicMethodNoAuth()
+	{
+		$response = $this->route('PermissionController/public');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testPublicMethodWithAuth()
+	{
+		$this->authenticate();
+		$response = $this->route('PermissionController/public');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testUnlistedMethodNoAuth()
+	{
+		$response = $this->route('PermissionController/noPermissionsListed');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testUnlistedMethodAuth()
+	{
+		$this->authenticate();
+		$response = $this->route('PermissionController/noPermissionsListed');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testUserPermissionNoAuth()
+	{
+		$response = $this->route('PermissionController/user');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testUserPermissionAuth()
+	{
+		$this->authenticate();
+		$response = $this->route('PermissionController/user');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	/**
+	 * @return void
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testUserPermissionBasicAuth()
+	{
+		require_once __DIR__ . '/../../test_files/models/OUsers.php';
+		$_SERVER['PHP_AUTH_USER'] = '';
+		$_SERVER['PHP_AUTH_PW'] = '';
+
+		$response = $this->route('PermissionController/user');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	/**
+	 * @return void
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testUserPermissionBasicAuthThatFails()
+	{
+		require_once __DIR__ . '/../../test_files/models/OUsers.php';
+		OUsers::$shouldAuthenticate = false;
+		$_SERVER['PHP_AUTH_USER'] = '';
+		$_SERVER['PHP_AUTH_PW'] = '';
+
+		$response = $this->route('PermissionController/user');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testNonGraduatedPermissionsNoAuth()
+	{
+		$response = $this->route('PermissionController/nonGraduated');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testNonGraduatedPermissionsAuth()
+	{
+		$this->authenticate();
+		$response = $this->route('PermissionController/nonGraduated');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testNonGraduatedPermissionsWrongAuth()
+	{
+		$this->authenticate();
+		$_SESSION['ouser']->ouser_permission_level = 2;
+		$response = $this->route('PermissionController/nonGraduated');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testGraduatedPermissionNoAuth()
+	{
+		define('__OBRAY_GRADUATED_PERMISSIONS__', true);
+		$response = $this->route('PermissionController/graduated');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testGraduatedPermissionAuth()
+	{
+		define('__OBRAY_GRADUATED_PERMISSIONS__', true);
+		$this->authenticate();
+		$response = $this->route('PermissionController/graduated');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testGraduatedPermissionGreaterAuth()
+	{
+		define('__OBRAY_GRADUATED_PERMISSIONS__', true);
+		$this->authenticate();
+		$_SESSION['ouser']->ouser_permission_level = 2;
+		$response = $this->route('PermissionController/graduated');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testGraduatedPermissionWrongAuth()
+	{
+		define('__OBRAY_GRADUATED_PERMISSIONS__', true);
+		$this->authenticate();
+		$_SESSION['ouser']->ouser_permission_level = 0;
+		$response = $this->route('PermissionController/graduated');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testNullPermissionLevel()
+	{
+		$this->authenticate();
+		$_SESSION['ouser']->ouser_permission_level = null;
+		$response = $this->route('PermissionController/nonGraduated');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testPermissionsNoAuth()
+	{
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testPermissionsAuthNoPermissions()
+	{
+		$this->authenticate();
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testPermissionsAuthPermissions()
+	{
+		$this->authenticate();
+		$_SESSION['ouser']->permissions = ['permission_access'];
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testPermissionsAuthWrongPermissions()
+	{
+		$this->authenticate();
+		$_SESSION['ouser']->permissions = ['different_access'];
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testRolesNoAuth()
+	{
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testRolesAuthNoPermissions()
+	{
+		$this->authenticate();
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testRolesAuthPermissions()
+	{
+		$this->authenticate();
+		$_SESSION['ouser']->roles = ['role_access'];
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testRolesAuthWrongPermissions()
+	{
+		$this->authenticate();
+		$_SESSION['ouser']->roles = ['different_access'];
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testPermissionAndRoleOfSameNameDeniesAccess()
+	{
+		$this->authenticate();
+		$_SESSION['ouser']->permissions = ['role_access'];
+		$_SESSION['ouser']->roles = ['permission_access'];
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertError($response, $this->defaultForbiddenErrors);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+
+	public function testSuperRole()
+	{
+		$this->authenticate();
+		$_SESSION['ouser']->roles = ['SUPER'];
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertNotError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+
+		// Test case-sensitivity
+		$_SESSION['ouser']->roles = ['super'];
+		$response = $this->route('PermissionController/permissionsAndRoles');
+
+		$this->assertError($response);
+		$this->assertInstanceOf(cPermissionController::class, $response);
+	}
+}

--- a/tests/Object/RouteTest.php
+++ b/tests/Object/RouteTest.php
@@ -31,6 +31,7 @@ class RouteTest extends TestCase
 		$response = $this->router->route('app/TestController/test', [], false);
 
 		$this->assertNotError();
+		$this->assertNotError($response);
 		$this->assertInstanceOf(OObject::class, $response);
 		$this->assertNotSame($this->router, $response);
 		$this->assertNotNull($response->data);


### PR DESCRIPTION
`ouser_permission_level` null literal:
If a user's ouser_permission_level field is null literal and the
permissions for an object or method are an integer, that user was
granted access. This fixes that bug.

Basic auth bug:
If a request had no authenticated session but provided basic auth
credentials and the permissions for an object or method are an integer,
that user was granted access. This fixes that bug.

Graduated permissions wrong logic:
If the constant `__OBRAY_GRADUATED_PERMISSIONS__` is defined and the
permissions for an object or method are an integer, the framework
checks if the user's `ouser_permission_level` is GREATER THAN the
required level, and if so DENIES the user access. This corrects the
behavior to check i the user's `ouser_permission_level` is LESS THAN
the required level, and if so DENIES the user access.