### PR TITLE
Pdo resolvers

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e81c3199d936b65b4442585b060d6e1f",
+    "content-hash": "cf9f52244f435ad3ad025728516020f5",
     "packages": [
         {
             "name": "illuminate/contracts",
@@ -2857,12 +2857,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "ext-curl": "*",
         "ext-pdo": "*",
         "ext-json": "*",
         "ext-openssl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/core/ODBO.php
+++ b/core/ODBO.php
@@ -99,6 +99,9 @@ class ODBO extends OObject
      */
     public $with;
 
+    protected static ?Closure $pdoResolver = null;
+    protected static ?Closure $readPdoResolver = null;
+
     public function __construct()
     {
         $this->primary_key_column = '';
@@ -130,6 +133,26 @@ class ODBO extends OObject
                 'password' => array('sql' => ' varchar(255) ', 'my_sql_type' => 'varchar(255)', 'validation_regex' => '')
             )));
         }
+    }
+
+    public static function setPdoResolver(?Closure $resolver): void
+    {
+        static::$pdoResolver = $resolver;
+    }
+
+    public static function setReadPdoResolver(?Closure $resolver): void
+    {
+        static::$readPdoResolver = $resolver;
+    }
+
+    public static function getPdoResolver(): ?Closure
+    {
+        return static::$pdoResolver;
+    }
+
+    public static function getReadPdoResolver(): ?Closure
+    {
+        return static::$readPdoResolver;
     }
 
     /**

--- a/core/functions.php
+++ b/core/functions.php
@@ -28,6 +28,11 @@ if (!function_exists('getDatabaseConnection')) {
 }
 
 if (!function_exists('getReaderDatabaseConnection')) {
+    /**
+     * Declares the global `$readConn` variable, builds a PDO object, sets `$readConn` to the PDO object, and returns the PDO object.
+     * @param $reconnect
+     * @return \PDO
+     */
     function getReaderDatabaseConnection($reconnect = false): PDO
     {
         global $readConn;

--- a/core/functions.php
+++ b/core/functions.php
@@ -1,6 +1,11 @@
 <?php
 
 if (!function_exists('getDatabaseConnection')) {
+    /**
+     * Declares the global `$conn` variable, builds a PDO object, sets `$conn` to the PDO object, and returns the PDO object.
+     * @param bool $reconnect
+     * @return \PDO
+     */
     function getDatabaseConnection(bool $reconnect = false): PDO
     {
         global $conn;

--- a/core/functions.php
+++ b/core/functions.php
@@ -1,11 +1,7 @@
 <?php
 
 if (!function_exists('getDatabaseConnection')) {
-    /**
-     * @param bool $reconnect
-     * @return \PDO
-     */
-    function getDatabaseConnection($reconnect = false)
+    function getDatabaseConnection(bool $reconnect = false): PDO
     {
         global $conn;
 
@@ -27,7 +23,7 @@ if (!function_exists('getDatabaseConnection')) {
 }
 
 if (!function_exists('getReaderDatabaseConnection')) {
-    function getReaderDatabaseConnection($reconnect = false)
+    function getReaderDatabaseConnection($reconnect = false): PDO
     {
         global $readConn;
 
@@ -53,7 +49,7 @@ if (!function_exists('getReaderDatabaseConnection')) {
 }
 
 if (!function_exists('buildDefaultPdoObject')) {
-    function buildDefaultPdoObject($host, $db, $username, $password)
+    function buildDefaultPdoObject($host, $db, $username, $password): PDO
     {
         $pdo = new PDO(
             'mysql:host=' . $host . ';dbname=' . $db . ';charset=utf8',

--- a/core/oWebSocketServer.php
+++ b/core/oWebSocketServer.php
@@ -60,7 +60,7 @@ class oWebSocketServer extends ODBO
 				$this->debug("Unable to create stream context: " . $err->getMessage() . "\n");
 				$this->throwError("Unable to create stream context: " . $err->getMessage());
                 $this->logError(static::class, $err);
-                return
+                return;
 			}
 
 		} else {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - .:/src
     working_dir: /src
+    user: 1000:1000
 
   mysql:
     image: mysql:5.7

--- a/tests/Odbo/OdboTestCase.php
+++ b/tests/Odbo/OdboTestCase.php
@@ -13,10 +13,7 @@ class OdboTestCase extends TestCase
 {
     use ResetsDatabase;
 
-    /**
-     * @var \ODBO
-     */
-    protected $testModel;
+    protected ODBO $testModel;
 
     protected function setUp(): void
     {

--- a/tests/Odbo/OdboTestCase.php
+++ b/tests/Odbo/OdboTestCase.php
@@ -44,10 +44,10 @@ class OdboTestCase extends TestCase
     public function testPdoAttributesArray(): void
     {
         define('__OBRAY_DATABASE_ATTRIBUTES__', [
-            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT,
         ]);
         $conn = getDatabaseConnection(true);
         $this->assertInstanceOf(PDO::class, $conn);
-        $this->assertSame(PDO::ERRMODE_EXCEPTION, $conn->getAttribute(PDO::ATTR_ERRMODE));
+        $this->assertSame(PDO::ERRMODE_SILENT, $conn->getAttribute(PDO::ATTR_ERRMODE));
     }
 }

--- a/tests/Odbo/OdboTestCase.php
+++ b/tests/Odbo/OdboTestCase.php
@@ -13,19 +13,19 @@ class OdboTestCase extends TestCase
 {
     use ResetsDatabase;
 
-	/**
-	 * @var \ODBO
-	 */
-	protected $testModel;
+    /**
+     * @var \ODBO
+     */
+    protected $testModel;
 
-	protected function setUp(): void
-	{
-		parent::setUp();
+    protected function setUp(): void
+    {
+        parent::setUp();
         $this->initializeResetsDatabase();
 
-		$this->testModel = new TestModel();
-		$this->testModel->dbh = getDatabaseConnection(true);
-	}
+        $this->testModel = new TestModel();
+        $this->testModel->dbh = getDatabaseConnection(true);
+    }
 
     protected function assertTimestampsEqualsWithDelta(DateTime|string $expected, DateTime|string $actual, $delta = 1)
     {
@@ -37,5 +37,20 @@ class OdboTestCase extends TestCase
         }
 
         $this->assertEqualsWithDelta($expected->getTimestamp(), $actual->getTimestamp(), $delta);
+    }
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     * @covers \buildDefaultPdoObject
+     */
+    public function testPdoAttributesArray(): void
+    {
+        define('__OBRAY_DATABASE_ATTRIBUTES__', [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ]);
+        $conn = getDatabaseConnection(true);
+        $this->assertInstanceOf(PDO::class, $conn);
+        $this->assertSame(PDO::ERRMODE_EXCEPTION, $conn->getAttribute(PDO::ATTR_ERRMODE));
     }
 }

--- a/tests/Odbo/ResolversTest.php
+++ b/tests/Odbo/ResolversTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace tests\Odbo;
+
+use ODBO;
+use PDO;
+use tests\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @covers \buildDefaultPdoObject
+ * @covers \getDatabaseConnection
+ * @covers \getReaderDatabaseConnection
+ * @covers \ODBO::setPdoResolver
+ * @covers \ODBO::setReadPdoResolver
+ * @covers \ODBO::getPdoResolver
+ * @covers \ODBO::getReadPdoResolver
+ */
+class ResolversTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        global $conn, $readConn;
+
+        unset($conn);
+        unset($readConn);
+    }
+
+    public function testDefaultPdoObjectIsBuilt(): void
+    {
+        $conn = getDatabaseConnection();
+        $this->assertInstanceOf(PDO::class, $conn);
+        $this->assertSame(PDO::ERRMODE_EXCEPTION, $conn->getAttribute(PDO::ATTR_ERRMODE));
+
+        // Reader not defined, should get reader back
+        $reader = getReaderDatabaseConnection();
+        $this->assertSame($conn, $reader);
+
+        global $readConn;
+        unset($readConn);
+
+        define('__OBRAY_DATABASE_HOST_READER__', __OBRAY_DATABASE_HOST__);
+        $conn = getReaderDatabaseConnection();
+        $this->assertInstanceOf(PDO::class, $conn);
+        $this->assertSame(PDO::ERRMODE_EXCEPTION, $conn->getAttribute(PDO::ATTR_ERRMODE));
+
+        // Ensure it works again, returning same object
+        $new = getReaderDatabaseConnection();
+        $this->assertSame($conn, $new);
+    }
+
+    public function testResolversAreCalled(): void
+    {
+        $f = function () {
+            $conn = buildDefaultPdoObject(
+                __OBRAY_DATABASE_HOST__,
+                __OBRAY_DATABASE_NAME__,
+                __OBRAY_DATABASE_USERNAME__,
+                __OBRAY_DATABASE_PASSWORD__
+            );
+            $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+            return $conn;
+        };
+        ODBO::setPdoResolver($f);
+        ODBO::setReadPdoResolver($f);
+
+        $conn = getDatabaseConnection();
+        $this->assertInstanceOf(PDO::class, $conn);
+        $this->assertSame(PDO::ERRMODE_SILENT, $conn->getAttribute(PDO::ATTR_ERRMODE), 'Error mode is not set to silent.');
+
+        $conn = getReaderDatabaseConnection();
+        $this->assertInstanceOf(PDO::class, $conn);
+        $this->assertSame(PDO::ERRMODE_SILENT, $conn->getAttribute(PDO::ATTR_ERRMODE), 'Error mode is not set to silent.');
+    }
+}


### PR DESCRIPTION
This lets us extend the framework with custom PDO resolution logic, should we need it.

```
/src $ XDEBUG_MODE=coverage,debug time ./vendor/bin/phpunit --coverage-html logs/coverage 
PHPUnit 9.6.16 by Sebastian Bergmann and contributors.

................................................................. 65 / 95 ( 68%)
..............................                                    95 / 95 (100%)

Time: 00:40.783, Memory: 8.00 MB

OK (95 tests, 513 assertions)

Generating code coverage report in HTML format ... done [00:01.034]
real	0m 41.92s
user	0m 31.40s
sys	0m 2.03s
```

![image](https://github.com/MaloufSleep/obray/assets/12569976/080169e6-495d-4097-8ddf-d98fc5fa065e)
